### PR TITLE
feat: adds support for double quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,12 @@
                     "description": "Use semicolon at the end of the statements ",
                     "type": "boolean",
                     "default": true
+                },
+                "wrap-console-log-simple.useSingleQuotes": {
+                    "title": "use single quotes",
+                    "description": "Wraps the selected variable in single quotes (double if unchecked) ",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,14 +67,15 @@ function handle(target: Wrap, prefix?: boolean, type?: string) {
         lastLine: doc.lineCount - 1 == lineNumber,
       };
       const semicolon = getSetting('useSemicolon') ? ';' : ''
+      const quote = getSetting("useSingleQuotes") ? `'` : `"`
       if (type === 'nameValue') {
-        wrapData.txt = funcName + "('".concat(wrapData.item, "', ", wrapData.item, ')', semicolon);
+        wrapData.txt = `${funcName}(${quote}${wrapData.item}${quote}, ${wrapData.item})${semicolon}`
       } else if (type === 'arguments') {
-        wrapData.txt = funcName + "('".concat(wrapData.item, "', ", 'arguments', ')', semicolon);
+        wrapData.txt = `${funcName}(${quote}${wrapData.item}${quote}, arguments)${semicolon}`
       } else if (type === 'get') {
-        wrapData.txt = "const aaa = get(".concat(wrapData.item, ", '", 'aaa', "', '')", semicolon);
+        wrapData.txt = `const aaa = get(${quote}${wrapData.item}${quote}, ${quote}aaa${quote}, ${quote}${quote})${semicolon}`
       } else {
-        wrapData.txt = funcName + "('".concat(wrapData.item, "')", semicolon);
+        wrapData.txt = `${funcName}(${quote}${wrapData.item}${quote})${semicolon}`
       }
       resolve(wrapData);
     }


### PR DESCRIPTION
#### Description
- Adds a new setting to disable single quotes.
- Refactors concatenated string with template literal.

#### Thoughts
I really enjoy this extension a lot but one of the problems I've ran into is trying to use it with languages (possible because you can change the function it uses) other than javascript/typescript, which throw errors for using single quotes around a string. Having to manually change the quotes in other languages is very tedious and being that users can add a custom function name I think It's reasonable they have an option to use double quotes instead of single quotes.